### PR TITLE
Warningを消せるだけ消した

### DIFF
--- a/components/optical_illusion/BrightnessContrast.js
+++ b/components/optical_illusion/BrightnessContrast.js
@@ -95,7 +95,7 @@ export default class BrightnessContrast extends Component {
           </Animated.View>
           <Animated.View style={[styles.outerSvg, {opacity: rectsOpacity}]}>
             <Svg height="150" width="150">
-              <Rect x="0" y="0" width="150" height="150" fill="#000000" stroke="null" strokeWidth="1"/>
+              <Rect x="0" y="0" width="150" height="150" fill="#000000" strokeWidth="1"/>
             </Svg>
           </Animated.View>
           <Animated.View style={[styles.outerSvg, {
@@ -103,12 +103,12 @@ export default class BrightnessContrast extends Component {
             left: leftRectLeft,
           }]}>
             <Svg height="40" width="40">
-              <Rect x="0" y="0" width="40" height="40" fill="#333333" stroke="null" strokeWidth="1"/>
+              <Rect x="0" y="0" width="40" height="40" fill="#333333" strokeWidth="1"/>
             </Svg>
             </Animated.View>
           <Animated.View style={[styles.outerSvg, {opacity: rectsOpacity, left: 150}]}>
             <Svg height="150" width="150">
-              <Rect x="0" y="0" width="150" height="150" fill="#eeeeee" stroke="null" strokeWidth="1"/>
+              <Rect x="0" y="0" width="150" height="150" fill="#eeeeee" strokeWidth="1"/>
             </Svg>
           </Animated.View>
           <Animated.View style={[styles.outerSvg, {
@@ -116,7 +116,7 @@ export default class BrightnessContrast extends Component {
             left: rightRectLeft,
           }]}>
             <Svg height="40" width="40">
-              <Rect x="0" y="0" width="40" height="40" fill="#333333" stroke="null" strokeWidth="1"/>
+              <Rect x="0" y="0" width="40" height="40" fill="#333333" strokeWidth="1"/>
             </Svg>
             </Animated.View>
         </View>

--- a/components/optical_illusion/Ehrenstein.js
+++ b/components/optical_illusion/Ehrenstein.js
@@ -149,7 +149,7 @@ class Circles extends Component {
     let viewArray = [];
     for (let i = 0; i < 90; i+=4) {
       viewArray.push(
-        <Circle cx="100" cy="100" r={i.toString()} fill="none" stroke="black" strokeWidth="1"/>
+        <Circle cx="100" cy="100" r={i.toString()} fill="none" stroke="black" strokeWidth="1" key={i}/>
       );
     }
     return (

--- a/components/optical_illusion/Zollner.js
+++ b/components/optical_illusion/Zollner.js
@@ -113,7 +113,7 @@ class Lines extends Component {
     let viewArray = [];
     for(let i = 0; i <= 255; i += 15 ) {
       viewArray.push(
-        <Line x1={i - num}  y1={Number(y) - 5} x2={i + num}  y2={Number(y) + 5} stroke="black" strokeWidth="1"/>
+        <Line x1={i - num}  y1={Number(y) - 5} x2={i + num}  y2={Number(y) + 5} stroke="black" strokeWidth="1" key={i}/>
       );
     }
     return (


### PR DESCRIPTION
もっとも多いopacityのWarningは、直すとSVG内がうまくアニメーションできないので、無視。